### PR TITLE
fix(ListenerLayer): implement safe fallback serializer for WAPI.proce…

### DIFF
--- a/WPP_Whatsapp/api/layers/ListenerLayer.py
+++ b/WPP_Whatsapp/api/layers/ListenerLayer.py
@@ -82,16 +82,36 @@ class ListenerLayer(ProfileLayer):
                         raise e
 
         await self.ThreadsafeBrowser.page_evaluate("""() => {
+        function _safeSerialize(msg) {
+          return {
+            id: typeof msg.id === 'object' ? msg.id._serialized : String(msg.id),
+            from: typeof msg.from === 'object' ? msg.from._serialized : String(msg.from || ''),
+            to: typeof msg.to === 'object' ? msg.to._serialized : String(msg.to || ''),
+            body: msg.body || '',
+            type: msg.type || 'chat',
+            t: msg.t || Math.floor(Date.now() / 1000),
+            isGroupMsg: !!msg.isGroupMsg,
+            sender: msg.sender && typeof msg.sender.id === 'object'
+              ? { id: msg.sender.id._serialized }
+              : msg.sender || {},
+          };
+        }
         try {
           if (!window['onMessage'].exposed) {
             WPP.on('chat.new_message', (msg) => {
               if (msg.isSentByMe || msg.isStatusV3) {
                 return;
               }
-              const serialized = WAPI.processMessageObj(msg, false, false);
-              if (serialized) {
-                window['onMessage'](serialized);
+              let serialized = null;
+              try {
+                serialized = WAPI.processMessageObj(msg, false, false);
+              } catch (e) {
+                console.warn('[WPP] processMessageObj failed, using fallback:', e.message);
               }
+              if (!serialized) {
+                serialized = _safeSerialize(msg);
+              }
+              window['onMessage'](serialized);
             });
 
             window['onMessage'].exposed = true;
@@ -102,10 +122,16 @@ class ListenerLayer(ProfileLayer):
         try {
           if (!window['onAnyMessage'].exposed) {
             WPP.on('chat.new_message', (msg) => {
-              const serialized = WAPI.processMessageObj(msg, true, false);
-              if (serialized) {
-                window['onAnyMessage'](serialized);
+              let serialized = null;
+              try {
+                serialized = WAPI.processMessageObj(msg, true, false);
+              } catch (e) {
+                console.warn('[WPP] processMessageObj (any) failed, using fallback:', e.message);
               }
+              if (!serialized) {
+                serialized = _safeSerialize(msg);
+              }
+              window['onAnyMessage'](serialized);
             });
             window['onAnyMessage'].exposed = true;
           }


### PR DESCRIPTION
### Problem
Starting with WhatsApp Web `v2.3000.x`, `WAPI.processMessageObj(msg)` crashes silently on the new internal message payload structures. The existing `try/catch` catches the error but only logs it to `console.error`, causing [onMessage](cci:1://file:///C:/projects/whatsTheGate/WPP_Whatsapp/WPP_Whatsapp/api/layers/ListenerLayer.py:312:4-319:56) and [onAnyMessage](cci:1://file:///C:/projects/whatsTheGate/WPP_Whatsapp/WPP_Whatsapp/api/layers/ListenerLayer.py:321:4-330:59) callbacks to never fire — completely breaking incoming message reception.

### Solution
Added a lightweight **fallback serializer** (`_safeSerialize`) inside `ListenerLayer._afterPageScriptInjectedListener()`. When `processMessageObj` throws, the fallback constructs a minimal-but-complete message payload directly from the raw WPP event object, ensuring the Python callback always receives data.

**Key design decisions:**
- `processMessageObj` is still tried first — this is a fallback, not a replacement
- Zero new dependencies or imports
- `console.warn` emitted when fallback is used, for diagnostic visibility
- Follows the existing inline-JS-via-[page_evaluate](cci:1://file:///C:/projects/whatsTheGate/WPP_Whatsapp/WPP_Whatsapp/controllers/browser.py:159:4-161:70) code style

### Fields in fallback payload
[id](cci:1://file:///C:/projects/whatsTheGate/WPP_Whatsapp/WPP_Whatsapp/api/layers/HostLayer.py:612:4-614:95), `from`, [to](cci:1://file:///C:/projects/whatsTheGate/WPP_Whatsapp/WPP_Whatsapp/controllers/browser.py:132:4-136:15), `body`, `type`, `t` (timestamp), `isGroupMsg`, `sender`

### Testing
Verified on WhatsApp Web `v2.3000.1023x` with `wa-js` nightly. Messages received correctly via fallback path, with `[WPP] processMessageObj failed, using fallback:` logged in browser console.
